### PR TITLE
Remove function call to obsolete TSML function

### DIFF
--- a/includes/admin-gen.php
+++ b/includes/admin-gen.php
@@ -206,7 +206,6 @@ function tsmp_gen_page() {
 
                 //pull eeting types from other plugin
                 global $tsml_programs;
-                tsml_define_strings() ;
                 $tsml_program = get_option('tsml_program', 'aa');
 
                 if(is_array($tsmp_filtering_types_what)){


### PR DESCRIPTION
In `3.12` we removed `tsml_define_strings` from our codebase. Users are now getting a fatal PHP error.